### PR TITLE
Update to MP6.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: maven
+  directory: "/"
+  schedule:
+    interval: monthly
+  open-pull-requests-limit: 50

--- a/finish/frontend/pom.xml
+++ b/finish/frontend/pom.xml
@@ -12,8 +12,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <liberty.var.default.http.port>9090</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9091</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9091</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -26,14 +26,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
           <groupId>com.ibm.websphere.appserver.api</groupId>
           <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
-          <version>1.1.75</version>
+          <version>1.1.84</version>
           <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -49,7 +49,7 @@
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
         </plugins>
     </build>

--- a/finish/frontend/src/main/liberty/config/server.xml
+++ b/finish/frontend/src/main/liberty/config/server.xml
@@ -11,15 +11,15 @@
         <feature>appSecurity-5.0</feature>
         <feature>servlet-6.0</feature>
         <feature>mpJwt-2.1</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
         <feature>mpRestClient-3.0</feature>
 
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9090"/>
-    <variable name="default.https.port" defaultValue="9091"/>
+    <variable name="http.port" defaultValue="9090"/>
+    <variable name="https.port" defaultValue="9091"/>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" 
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}" 
                   id="defaultHttpEndpoint" />
 
     <keyStore id="defaultKeyStore" password="secret" />

--- a/finish/system/pom.xml
+++ b/finish/system/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.default.hostname>localhost</liberty.var.default.hostname>
-        <liberty.var.default.http.port>8080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>8443</liberty.var.default.https.port>
+        <liberty.var.http.port>8080</liberty.var.http.port>
+        <liberty.var.https.port>8443</liberty.var.https.port>
         <jwt.issuer>http://openliberty.io</jwt.issuer>
     </properties>
 
@@ -43,25 +43,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
              <artifactId>resteasy-client</artifactId>
-             <version>6.2.3.Final</version>
+             <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
              <artifactId>resteasy-json-binding-provider</artifactId>
-             <version>6.2.3.Final</version>
+             <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.91.Final</version>
+            <version>4.1.106.Final</version>
             <classifier>osx-x86_64</classifier>
             <scope>test</scope>
         </dependency>
@@ -97,23 +97,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <hostname>${liberty.var.default.hostname}</hostname>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/finish/system/src/main/liberty/config/server.xml
+++ b/finish/system/src/main/liberty/config/server.xml
@@ -5,7 +5,7 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
     <feature>appSecurity-5.0</feature>
     <feature>servlet-6.0</feature>
@@ -14,12 +14,12 @@
     <!-- end::mpJwt[] -->
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="8080"/>
-  <variable name="default.https.port" defaultValue="8443"/>
+  <variable name="http.port" defaultValue="8080"/>
+  <variable name="https.port" defaultValue="8443"/>
 
   <keyStore id="defaultKeyStore" password="secret"/>
   
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}"
                 id="defaultHttpEndpoint"/>
                  
   <webApplication location="system.war" contextRoot="/"/>

--- a/finish/system/src/main/webapp/index.html
+++ b/finish/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpJwt-2.1.html" target="_blank" rel="noopener noreferrer">MicroProfile JSON Web Token 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>

--- a/start/frontend/pom.xml
+++ b/start/frontend/pom.xml
@@ -12,8 +12,8 @@
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <maven.compiler.source>11</maven.compiler.source>
         <maven.compiler.target>11</maven.compiler.target>
-        <liberty.var.default.http.port>9090</liberty.var.default.http.port>
-        <liberty.var.default.https.port>9091</liberty.var.default.https.port>
+        <liberty.var.http.port>9090</liberty.var.http.port>
+        <liberty.var.https.port>9091</liberty.var.https.port>
     </properties>
 
     <dependencies>
@@ -26,14 +26,14 @@
         <dependency>
             <groupId>org.eclipse.microprofile</groupId>
             <artifactId>microprofile</artifactId>
-            <version>6.0</version>
+            <version>6.1</version>
             <type>pom</type>
             <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.ibm.websphere.appserver.api</groupId>
             <artifactId>com.ibm.websphere.appserver.api.jwt</artifactId>
-            <version>1.1.75</version>
+            <version>1.1.84</version>
             <scope>provided</scope>
         </dependency>
     </dependencies>
@@ -49,7 +49,7 @@
              <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
         </plugins>
     </build>

--- a/start/frontend/src/main/liberty/config/server.xml
+++ b/start/frontend/src/main/liberty/config/server.xml
@@ -11,15 +11,15 @@
         <feature>appSecurity-5.0</feature>
         <feature>servlet-6.0</feature>
         <feature>mpJwt-2.1</feature>
-        <feature>mpConfig-3.0</feature>
+        <feature>mpConfig-3.1</feature>
         <feature>mpRestClient-3.0</feature>
 
     </featureManager>
 
-    <variable name="default.http.port" defaultValue="9090"/>
-    <variable name="default.https.port" defaultValue="9091"/>
+    <variable name="http.port" defaultValue="9090"/>
+    <variable name="https.port" defaultValue="9091"/>
 
-    <httpEndpoint httpPort="${default.http.port}" httpsPort="${default.https.port}" 
+    <httpEndpoint httpPort="${http.port}" httpsPort="${https.port}" 
                   id="defaultHttpEndpoint" />
 
     <keyStore id="defaultKeyStore" password="secret" />

--- a/start/system/pom.xml
+++ b/start/system/pom.xml
@@ -17,8 +17,8 @@
         <maven.compiler.target>11</maven.compiler.target>
         <!-- Liberty configuration -->
         <liberty.var.default.hostname>localhost</liberty.var.default.hostname>
-        <liberty.var.default.http.port>8080</liberty.var.default.http.port>
-        <liberty.var.default.https.port>8443</liberty.var.default.https.port>
+        <liberty.var.http.port>8080</liberty.var.http.port>
+        <liberty.var.https.port>8443</liberty.var.https.port>
         <jwt.issuer>http://openliberty.io</jwt.issuer>
     </properties>
 
@@ -43,25 +43,25 @@
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
-            <version>3.12.0</version>
+            <version>3.14.0</version>
         </dependency>
         <!-- For tests-->
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
-            <version>5.9.2</version>
+            <version>5.10.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
              <artifactId>resteasy-client</artifactId>
-             <version>6.2.3.Final</version>
+             <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.jboss.resteasy</groupId>
              <artifactId>resteasy-json-binding-provider</artifactId>
-             <version>6.2.3.Final</version>
+             <version>6.2.7.Final</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -73,13 +73,13 @@
         <dependency>
             <groupId>io.vertx</groupId>
             <artifactId>vertx-auth-jwt</artifactId>
-            <version>4.4.1</version>
+            <version>4.5.1</version>
             <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-resolver-dns-native-macos</artifactId>
-            <version>4.1.91.Final</version>
+            <version>4.1.106.Final</version>
             <classifier>osx-x86_64</classifier>
             <scope>test</scope>
         </dependency>
@@ -97,23 +97,23 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
             </plugin>
             <!-- Enable liberty-maven plugin -->
             <plugin>
                 <groupId>io.openliberty.tools</groupId>
                 <artifactId>liberty-maven-plugin</artifactId>
-                <version>3.8.2</version>
+                <version>3.10</version>
             </plugin>
             <!-- Plugin to run functional tests -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-failsafe-plugin</artifactId>
-                <version>3.0.0</version>
+                <version>3.2.5</version>
                 <configuration>
                     <systemPropertyVariables>
                         <hostname>${liberty.var.default.hostname}</hostname>
-                        <http.port>${liberty.var.default.http.port}</http.port>
+                        <http.port>${liberty.var.http.port}</http.port>
                     </systemPropertyVariables>
                 </configuration>
             </plugin>

--- a/start/system/src/main/liberty/config/server.xml
+++ b/start/system/src/main/liberty/config/server.xml
@@ -5,18 +5,18 @@
     <feature>jsonb-3.0</feature>
     <feature>jsonp-2.1</feature>
     <feature>cdi-4.0</feature>
-    <feature>mpConfig-3.0</feature>
+    <feature>mpConfig-3.1</feature>
     <feature>mpRestClient-3.0</feature>
     <feature>appSecurity-5.0</feature>
     <feature>servlet-6.0</feature>
   </featureManager>
 
-  <variable name="default.http.port" defaultValue="8080"/>
-  <variable name="default.https.port" defaultValue="8443"/>
+  <variable name="http.port" defaultValue="8080"/>
+  <variable name="https.port" defaultValue="8443"/>
 
   <keyStore id="defaultKeyStore" password="secret"/>
 
-  <httpEndpoint host="*" httpPort="${default.http.port}" httpsPort="${default.https.port}"
+  <httpEndpoint host="*" httpPort="${http.port}" httpsPort="${https.port}"
                 id="defaultHttpEndpoint"/>
 
   <webApplication location="system.war" contextRoot="/"/>

--- a/start/system/src/main/webapp/index.html
+++ b/start/system/src/main/webapp/index.html
@@ -1,5 +1,5 @@
 <!--
-  Copyright (c) 2016, 2023 IBM Corp.
+  Copyright (c) 2016, 2024 IBM Corp.
 
   Licensed under the Apache License, Version 2.0 (the "License");
   you may not use this file except in compliance with the License.
@@ -30,10 +30,10 @@
     <p>
         For more information about the features used in this application, see the Open Liberty documentation:
         <ul>
-            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.0.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#microProfile-6.1.html" target="_blank" rel="noopener noreferrer">MicroProfile 6.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpJwt-2.1.html" target="_blank" rel="noopener noreferrer">MicroProfile JSON Web Token 2.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#mpRestClient-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Rest Client 3.0</a></li>
-            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.0.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.0</a></li>
+            <li><a href="https://openliberty.io/docs/ref/feature/#mpConfig-3.1.html" target="_blank" rel="noopener noreferrer">MicroProfile Config 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#cdi-4.0.html" target="_blank" rel="noopener noreferrer">Jakarta Contexts and Dependency Injection 4.0</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#restfulWS-3.1.html" target="_blank" rel="noopener noreferrer">Jakarta RESTful Web Services 3.1</a></li>
             <li><a href="https://openliberty.io/docs/ref/feature/#jsonp-2.1.html" target="_blank" rel="noopener noreferrer">Jakarta JSON Processing 2.1</a></li>


### PR DESCRIPTION
address issue: https://github.com/OpenLiberty/guides-common/issues/1021

### Review changes
- [ ] pom.xml
  - microfile-profile is 6.1, and dependencies
  - LMP 3.10
  - `default.` should be removed
  - ports `9090`,`9453`,`9091`,`9454` if guide uses local kube
- [ ] server.xml
  - feature version
- [ ] index.html
  - feature version
- [ ] update lgdev with `version-update-mp61` branch
- [ ] do end-to-end test and review content carefully
  - clone the `version-update-mp61` branch
  - if index.html has changes, make sure the links work

